### PR TITLE
Indicação de campos obrigatórios nos formulários

### DIFF
--- a/src/app/autor/autor-adicionar-editar/autor-adicionar-editar.component.html
+++ b/src/app/autor/autor-adicionar-editar/autor-adicionar-editar.component.html
@@ -4,10 +4,11 @@
       <div class="card-body">
   
         <form #formAutor="ngForm" novalidate>
-                    
+          <span class="text-table text-danger">Os campos marcados com * são obrigatórios</span>
+          <!-- Row 1 -->
           <div class="form-row">
             <div class="col-4 mb-3">
-              <label>Autor</label>
+              <label>Autor</label><span class="text-danger"> *</span>
                 <div class="input-group">
                   <input type="text" class="form-control form-control-sm"
                     [class.is-valid]="iptAutor.valid && (iptAutor.dirty || iptAutor.touched)"
@@ -19,8 +20,9 @@
                 </div>
             </div>
 
+            <!-- Row 2 -->
             <div class="col-4 mb-3">
-              <label>Cargo</label>
+              <label>Cargo</label><span class="text-danger"> *</span>
                 <div class="input-group">
                   <input type="text" class="form-control form-control-sm"
                     [class.is-valid]="iptCargo.valid && (iptCargo.dirty || iptCargo.touched)"
@@ -32,8 +34,9 @@
                 </div>
             </div>
 
+            <!-- Row 3 -->
             <div class="col-4 mb-3">
-              <label>Partido</label>
+              <label>Partido</label><span class="text-danger"> *</span>
                 <div class="input-group">
                   <input type="text" class="form-control form-control-sm"
                     [class.is-valid]="iptPartido.valid && (iptPartido.dirty || iptPartido.touched)"

--- a/src/app/emenda/emenda-adicionar-editar/emenda-adicionar-editar.component.ts
+++ b/src/app/emenda/emenda-adicionar-editar/emenda-adicionar-editar.component.ts
@@ -2,6 +2,8 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Route, Router } from '@angular/router';
 
 import { EmendaService } from '../emenda.service';
+import { LegislacaoService } from './../../legislacao/legislacao.service';
+import { AutorService } from './../../autor/autor.service';
 
 import { RadioOption } from './../../shared/radio/radio-option.model';
 import Swal from 'sweetalert2';
@@ -78,7 +80,10 @@ export class EmendaAdicionarEditarComponent implements OnInit {
 
   impedimentoOptions: RadioOption[] = [{label: 'Sim', value:'1'}, {label: 'Não', value:'0'}]
 
-  constructor(private emendaService: EmendaService, private route: ActivatedRoute, private router: Router) { }
+  constructor(private emendaService: EmendaService,
+              private legislacaoService: LegislacaoService,
+              private autorService: AutorService,
+              private route: ActivatedRoute, private router: Router) { }
 
   ngOnInit() {
     this.route.params.subscribe(res => this.params = res);
@@ -126,12 +131,12 @@ export class EmendaAdicionarEditarComponent implements OnInit {
   }
 
   getLegislacoes() {
-    this.emendaService.getLegislacoes()
+    this.legislacaoService.getLegislacoes()
       .subscribe(legislacoes => this.legislacoes = legislacoes)
   }
 
   getLegislacaoById(ano: number) {
-    this.emendaService.getLegislacaoById(ano)
+    this.legislacaoService.getLegislacaoById(ano)
       .subscribe(legislacao => {
         this.legislacao = legislacao;
         if(this.legislacao.dt_indicacao_beneficiario)
@@ -156,12 +161,12 @@ export class EmendaAdicionarEditarComponent implements OnInit {
   }
 
   getAutores() {
-    this.emendaService.getAutores()
+    this.autorService.getAutores()
       .subscribe(autores => this.autores = autores)
   }
 
   getAutorById(cod_autor: number) {
-    this.emendaService.getAutoresById(cod_autor)
+    this.autorService.getAutoresById(cod_autor)
       .subscribe(autor => this.autor = autor)
   }
 

--- a/src/app/emenda/emenda.service.ts
+++ b/src/app/emenda/emenda.service.ts
@@ -40,28 +40,12 @@ export class EmendaService {
         return this.http.get<Emenda>(`${EP_API}/emendas/${cod_emenda}`)
     }
 
-    getLegislacoes(): Observable<any[]> {
-        return this.http.get<any[]>(`${EP_API}/legislacoes`)
-    }
-
-    getLegislacaoById(ano: number): Observable<Emenda> {
-        return this.http.get<Emenda>(`${EP_API}/legislacoes/${ano}`)
-    }
-
     getUfs(): Observable<any[]> {
         return this.http.get<any[]>(`${EP_API}/ufs`)
     }
 
     getMunicipiosByUf(uf: string): Observable<any[]> {
         return this.http.get<any[]>(`${EP_API}/municipios/${uf}`)
-    }
-
-    getAutores(): Observable<any[]> {
-        return this.http.get<any[]>(`${EP_API}/autores`)
-    }
-
-    getAutoresById(cod_autor: number): Observable<any[]> {
-        return this.http.get<any[]>(`${EP_API}/autores/${cod_autor}`);
     }
 
     getFontes(): Observable<any[]> {

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,11 +1,11 @@
 <header>
-  <nav class="navbar navbar-expand-lg navbar-light bg-azul-padrao">
+  <nav class="navbar navbar-expand-lg navbar-dark bg-azul-padrao">
     <div class="container-fluid">
       <div class="navbar-nav">
-        <a class="nav-item nav-link text-white" [routerLink]="['/']">Início</a>
-        <a class="nav-item nav-link text-white" [routerLink]="['/emendas']">Emendas Parlamentares</a>
-        <a class="nav-item nav-link text-white" [routerLink]="['/legislacao']">Legislação</a>
-        <a class="nav-item nav-link text-white" [routerLink]="['/autor']">Autor</a>
+        <a class="nav-item nav-link" [routerLink]="['/']">Início</a>
+        <a routerLinkActive="active" class="nav-item nav-link" [routerLink]="['/emendas']">Emendas Parlamentares</a>
+        <a routerLinkActive="active" class="nav-item nav-link" [routerLink]="['/legislacao']">Legislação</a>
+        <a routerLinkActive="active" class="nav-item nav-link" [routerLink]="['/autor']">Autor</a>
       </div>
     </div>
   </nav>

--- a/src/app/legislacao/legislacao-adicionar-editar/legislacao-adicionar-editar.component.html
+++ b/src/app/legislacao/legislacao-adicionar-editar/legislacao-adicionar-editar.component.html
@@ -4,11 +4,11 @@
     <div class="card-body">
 
       <form #formLegislacao="ngForm" novalidate>
-
+        <span class="text-table text-danger">Os campos marcados com * são obrigatórios</span>
         <!-- Row 1 -->
         <div class="form-row">
           <div class="col-4 mb-3">
-            <label>Ano</label>
+            <label>Ano</label><span class="text-danger"> *</span>
             <div class="input-group">
               <input type="text" class="form-control form-control-sm"
                 [class.is-valid]="iptAno.valid && (iptAno.dirty || iptAno.touched)"


### PR DESCRIPTION
Indicação dos campos obrigatórios nos formulários de Legislação e Autor;
Alteração no Barra de Navegação para mostrar qual a aba ativa.
Retirado os métodos repetidos do service de Emenda: agora os Gets de  legislação e autor são chamados pelo service de Legislação e Autor.